### PR TITLE
Decrease gem package size

### DIFF
--- a/regexp_trie.gemspec
+++ b/regexp_trie.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   }
 
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|example)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
# Problem


regexp_trie gem package is very large.
It is 5.1MB on RubyGems.org https://rubygems.org/gems/regexp_trie (I guess it is compressed package size).
And it is 19MB on local. i checked it with `du /path/to/installed/path/regexp_trie-1.0.2/ --summarize -h`.



Because the package includes `example/` package and it has a large text file.


# Solution


Remove the `example/` directory from the package.


I think the `example/` directory is not necessary for the package. Because we can try the example with a `git clone`d repository instead of `gem install`ed package directory.


---


I've confirmed the package size is decreased to 64KB on my local with `du` command.
